### PR TITLE
Add tutorial navigation button to calculator page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,11 +43,32 @@
             background-color: #e9ecef;
             border-radius: 4px;
         }
+        .tutorial-link {
+            display: inline-block;
+            background-color: #28a745;
+            color: white;
+            text-decoration: none;
+            padding: 8px 15px;
+            border-radius: 4px;
+            margin-bottom: 15px;
+        }
+        .tutorial-link:hover {
+            background-color: #218838;
+        }
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
     </style>
 </head>
 <body>
     <div class="calculator">
-        <h1>Calculator</h1>
+        <div class="header">
+            <h1>Calculator</h1>
+            <a href="tutorial.html" class="tutorial-link">How to Use</a>
+        </div>
         <div class="input-group">
             <input type="number" id="num1" placeholder="First number">
             <input type="number" id="num2" placeholder="Second number">


### PR DESCRIPTION
This PR adds a "How to Use" button to the calculator page that links to the tutorial page. Changes include:

1. Added a new "How to Use" button in the calculator header
2. Styled the button to match the existing design while being distinct
3. Created a header section to properly align the title and tutorial button

The tutorial page already had a "Back to Calculator" link, so this completes the bidirectional navigation between the pages.

Related issues:
- Closes #34 (Add button that redirects between index.html and tutorial.html)
- Related to #22 (Original issue for creating the tutorial page)
- Related to PR #23 (Which added the tutorial page initially)

Testing:
- Click "How to Use" button on calculator page to go to tutorial
- Click "Back to Calculator" on tutorial page to return
- Verified styling is consistent with the application's design