### PR TITLE
Add factorial calculator functionality

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -112,7 +112,7 @@
         </div>
 
         <div class="input-group single-input" id="singleInput">
-            <input type="number" id="num" placeholder="Enter degrees">
+            <input type="number" id="num" placeholder="Enter number">
         </div>
 
         <div class="operations">
@@ -121,6 +121,7 @@
             <button onclick="calculate('multiply')">Multiply (×)</button>
             <button onclick="calculate('divide')">Divide (÷)</button>
             <button onclick="calculate('sqrt')">Square Root (√)</button>
+            <button onclick="calculate('factorial')">Factorial (!)</button>
             <button onclick="calculate('bhaskara')">Solve Quadratic</button>
             <button onclick="calculate('sin')">Sin (°)</button>
             <button onclick="calculate('cos')">Cos (°)</button>
@@ -133,7 +134,7 @@
     </div>
 
     <script type="module">
-        import { sum, subtract, multiply, divide, sqrt, bhaskara, sin, cos, tan } from './math/operations.js';
+        import { sum, subtract, multiply, divide, sqrt, bhaskara, sin, cos, tan, factorial } from './math/operations.js';
 
         function toggleInputs(mode) {
             const singleInput = document.getElementById('singleInput');
@@ -156,15 +157,33 @@
         window.calculate = async function(operation) {
             let result;
             try {
-                if (operation === 'sqrt') {
+                if (operation === 'sqrt' || operation === 'factorial' || ['sin', 'cos', 'tan'].includes(operation)) {
                     toggleInputs('single');
                     const num = parseFloat(document.getElementById('num').value);
                     if (isNaN(num)) {
                         document.getElementById('output').textContent = 'Please enter a valid number';
                         return;
                     }
-                    result = sqrt(num);
-                    document.getElementById('output').textContent = result;
+                    
+                    switch(operation) {
+                        case 'sqrt':
+                            result = sqrt(num);
+                            break;
+                        case 'factorial':
+                            result = factorial(num);
+                            break;
+                        case 'sin':
+                            result = sin(num);
+                            break;
+                        case 'cos':
+                            result = cos(num);
+                            break;
+                        case 'tan':
+                            result = tan(num);
+                            break;
+                    }
+                    
+                    document.getElementById('output').textContent = operation === 'factorial' ? result : result.toFixed(4);
                 } else if (operation === 'bhaskara') {
                     toggleInputs('triple');
                     const a = parseFloat(document.getElementById('quad-a').value);
@@ -178,25 +197,6 @@
                     
                     const roots = bhaskara(a, b, c);
                     document.getElementById('output').textContent = `x₁ = ${roots.x1.toFixed(2)}, x₂ = ${roots.x2.toFixed(2)}`;
-                } else if (['sin', 'cos', 'tan'].includes(operation)) {
-                    toggleInputs('single');
-                    const degrees = parseFloat(document.getElementById('num').value);
-                    if (isNaN(degrees)) {
-                        document.getElementById('output').textContent = 'Please enter a valid number';
-                        return;
-                    }
-                    switch(operation) {
-                        case 'sin':
-                            result = sin(degrees);
-                            break;
-                        case 'cos':
-                            result = cos(degrees);
-                            break;
-                        case 'tan':
-                            result = tan(degrees);
-                            break;
-                    }
-                    document.getElementById('output').textContent = result.toFixed(4);
                 } else {
                     toggleInputs('double');
                     const num1 = parseFloat(document.getElementById('num1').value);

--- a/src/math/operations.test.ts
+++ b/src/math/operations.test.ts
@@ -1,4 +1,4 @@
-import { sum, subtract, multiply, divide, exponentiate, sqrt, bhaskara, sin, cos, tan } from './operations';
+import { sum, subtract, multiply, divide, exponentiate, sqrt, bhaskara, sin, cos, tan, factorial } from './operations';
 
 describe('Math Operations', () => {
   describe('sum', () => {
@@ -214,6 +214,30 @@ describe('Math Operations', () => {
     it('should handle angles > 360', () => {
       expect(tan(405)).toBeCloseTo(1);
       expect(() => tan(450)).toThrow('Tangent is undefined for degrees that are odd multiples of 90');
+    });
+  });
+
+  describe('factorial', () => {
+    it('should calculate factorial for positive integers correctly', () => {
+      expect(factorial(0)).toBe(1);
+      expect(factorial(1)).toBe(1);
+      expect(factorial(5)).toBe(120);
+    });
+
+    it('should handle edge cases', () => {
+      expect(factorial(2)).toBe(2);
+      expect(factorial(3)).toBe(6);
+      expect(factorial(4)).toBe(24);
+    });
+
+    it('should throw error for negative numbers', () => {
+      expect(() => factorial(-1)).toThrow('Factorial is not defined for negative numbers');
+      expect(() => factorial(-5)).toThrow('Factorial is not defined for negative numbers');
+    });
+
+    it('should throw error for non-integer numbers', () => {
+      expect(() => factorial(1.5)).toThrow('Factorial is only defined for integers');
+      expect(() => factorial(2.7)).toThrow('Factorial is only defined for integers');
     });
   });
 });

--- a/src/math/operations.ts
+++ b/src/math/operations.ts
@@ -81,3 +81,16 @@ export const tan = (degrees: number): number => {
     // Convert degrees to radians and calculate tangent
     return Math.tan(degrees * Math.PI / 180);
 };
+
+export const factorial = (n: number): number => {
+    if (!Number.isInteger(n)) {
+        throw new Error('Factorial is only defined for integers');
+    }
+    if (n < 0) {
+        throw new Error('Factorial is not defined for negative numbers');
+    }
+    if (n === 0 || n === 1) {
+        return 1;
+    }
+    return n * factorial(n - 1);
+};


### PR DESCRIPTION
Closes #55

This PR adds a factorial calculator function to the calculator application.

### Implementation Details
- Added `factorial(n)` function to `operations.ts` with proper error handling
- Follows existing code patterns and error handling conventions
- Handles edge cases (negative numbers, non-integers)
- Integrated into UI using single input mode, consistent with sqrt and trigonometric functions

### Test Coverage
- Added comprehensive test suite in `operations.test.ts`:
  - Basic factorial calculations (0!, 1!, 5!)
  - Edge cases (2!, 3!, 4!)
  - Error handling for negative numbers
  - Error handling for non-integer inputs

### UI Changes
- Added "Factorial (!)" button to calculator interface
- Reuses existing single-input mode
- Maintains consistent UI styling and error display

### Related Issues
After reviewing similar issues in the repository:
- #22 (sim=0.435): Similar in adding new UI functionality, but for tutorial page
- #18 (sim=0.435): Related to calculator UI, but focused on landing page
No direct duplicates or blocking issues found.

### Testing Notes
1. Basic functionality:
   - Calculate factorial of 0 (should be 1)
   - Calculate factorial of 5 (should be 120)
2. Error cases:
   - Try negative numbers (should show error)
   - Try decimal numbers (should show error)
3. UI integration:
   - Verify input field visibility
   - Verify error message display